### PR TITLE
mediatek: Add mt8196 VCP firmware

### DIFF
--- a/WHENCE
+++ b/WHENCE
@@ -5926,6 +5926,15 @@ Licence: Redistributable. See LICENCE.mediatek for details.
 
 --------------------------------------------------------------------------
 
+Driver: mt8196 - MediaTek MT8196 Video Controller Processor
+
+File: mediatek/mt8196/vcp.img
+Version: v1.0.0
+
+Licence: Redistributable. See LICENCE.mediatek for details.
+
+--------------------------------------------------------------------------
+
 Driver: mtk_scp - MediaTek SCP System Control Processing Driver
 
 File: mediatek/mt8183/scp.img


### PR DESCRIPTION
MediaTek's Video Companion Processor(VCP) is an RISC-V processor in MediaTek MT8196 SoC.
It supports vedio encode/decode, vmm and vdisp feature.

Release version: 202505150344